### PR TITLE
change certificate-validation record behavior

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,9 @@ data "aws_route53_zone" "zone" {
 resource "aws_route53_record" "record" {
   for_each = {
     for dvo in aws_acm_certificate.cert.0.domain_validation_options : dvo.domain_name => {
-      name  = dvo.resource_record_name
+      name   = dvo.resource_record_name
       record = dvo.resource_record_value
-      type  = dvo.resource_record_type
+      type   = dvo.resource_record_type
 
       zone_id = data.aws_route53_zone.zone[local.host_to_zone[dvo.domain_name]].zone_id
     }

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,3 @@ resource "aws_acm_certificate_validation" "cert_validation" {
 
   provider = aws.acm
 }
-
-  provider = aws.acm
-}


### PR DESCRIPTION
change the resource "aws_route53_record" "record" - for_each behavior. 

Tested  as cert module only and also as embedded module in [redirect-module ](https://github.com/mediapop/terraform-aws-redirect)

Please be sure to change the dependencies in your other modules where this module is embedded.