### PR TITLE
Remove explicit provider config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,8 @@
-provider "aws" {
-  region = "us-east-1"
-  alias  = "acm"
-}
-
 resource "aws_acm_certificate" "cert" {
   count                     = local.certificates_issued
   domain_name               = local.domain
   subject_alternative_names = local.subject_alternative_names
   validation_method         = "DNS"
-  provider                  = aws.acm
 
   lifecycle {
     create_before_destroy = true
@@ -50,5 +44,4 @@ resource "aws_acm_certificate_validation" "cert_validation" {
     for record in aws_route53_record.record : record.fqdn
   ]
 
-  provider = aws.acm
 }


### PR DESCRIPTION
Terraform now recommends that modules do not explicitly configure providers. This should be inherited from the calling module

This is particularly problematic when using https://github.com/mediapop/terraform-aws-redirect as my main terraform config uses the AWS provider with an assumed role, but this sub-submodule was not picking up that configuration as it had its own provider block, and as a sub-submodule there was no way to pass the provider configuration down.